### PR TITLE
Update build-info-extractor-gradle

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -30,7 +30,7 @@ buildscript {
     dependencies {
         classpath "org.akhikhl.gretty:gretty:1.2.4"
         classpath "nl.eveoh:gradle-aspectj:1.6"
-		classpath(group: 'org.jfrog.buildinfo', name: 'build-info-extractor-gradle', version: '4.0.0')
+		classpath(group: 'org.jfrog.buildinfo', name: 'build-info-extractor-gradle', version: '4.4.13')
 		classpath(group: 'wavity-gradle-plugins', name: 'plugins', version: '1.0.0')
     }
     configurations.all {


### PR DESCRIPTION
Changing build-info-extractor-gradle version to be compatible with new Jenkins / Artifactory.
I think this shouldn't impact functionality. Let me know.